### PR TITLE
Fix broken TileJSON link

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
               <br>Zoom 13 building merge is disabled, additional languages from <a href="https://wikidata.org/">Wikidata</a>.
               <br>Schema <a href="https://openmaptiles.org/">&copy; OpenMapTiles</a>, map data <a href="https://openstreetmap.org/copyright">&copy; OpenStreetMap contributors</a>.</p>
             <p class="services">
-              services: <a href="https://dwuxtsziek7cf.cloudfront.net/planet.json">TileJSON</a> | <a href="rss.xml" class="icon"><img src="rss.png" description="RSS icon" />Build Status</a>
+              services: <a href="https://vt.ourmap.us/planet.json">TileJSON</a> | <a href="rss.xml" class="icon"><img src="rss.png" description="RSS icon" />Build Status</a>
             </p>
           </div>
           <div class="viewers">


### PR DESCRIPTION
Changes old CloudFront TileJSON address to https://vt.ourmap.us/planet.json