### PR TITLE
Refresh wikidata names periodically

### DIFF
--- a/renderer/render_once.sh
+++ b/renderer/render_once.sh
@@ -29,7 +29,7 @@ docker run -e JAVA_TOOL_OPTIONS='-Xmx2g' \
 	-v "$WORKING_DIR/data":/data \
 	-v "$DIR/layers":/layers \
 	ghcr.io/onthegomap/planetiler:latest --area=planet \
-	--download --download-only --only-fetch-wikidata
+	--download --download-only --only-fetch-wikidata --wikidata-max-age=P30D --wikidata-update-limit=100000
 
 # Remove default downloaded OSM file
 rm -rf "$WORKING_DIR/data/sources/monaco.osm.pbf"


### PR DESCRIPTION
Use new flags added in https://github.com/onthegomap/planetiler/pull/971 to refresh wikidata name translations every 30 days.