### PR TITLE
Upload tiles to Cloudflare R2 (in addition to AWS S3)

### DIFF
--- a/renderer/render_once.sh
+++ b/renderer/render_once.sh
@@ -82,7 +82,10 @@ for file in "$DIR/layers/"*.yml; do
 
 	echo "Uploading $layer_name to s3 bucket in background"
 	{
+		# upload to AWS S3 bucket
 		aws s3 cp "$WORKING_DIR/data/$layer_name.pmtiles" s3://osmus-tile/ --only-show-errors
+		# also upload the same data to a Cloudflare R2 bucket (testing this as a new hosting option)
+		env AWS_PROFILE=osmus-r2 aws s3 cp "$WORKING_DIR/data/$layer_name.pmtiles" s3://osmus-tile/ --only-show-errors
 		rm -rf "$WORKING_DIR/data/$layer_name.pmtiles"
 	} &
 done


### PR DESCRIPTION
We're testing Cloudflare R2 as an option for hosting tiles (they have very competitive storage and edge compute pricing).

Pyrene has been updated with credentials for the R2 bucket under the profile name `osmus-r2`.