### PR TITLE
Use Hono for HTTP handling in Cloudflare worker

### DIFF
--- a/cloudflare/package-lock.json
+++ b/cloudflare/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pmtiles-cloudflare",
       "version": "0.0.1",
       "dependencies": {
+        "hono": "^4.9.2",
         "pmtiles": "^4.2.1"
       },
       "devDependencies": {
@@ -1415,6 +1416,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/hono": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.2.tgz",
+      "integrity": "sha512-UG2jXGS/gkLH42l/1uROnwXpkjvvxkl3kpopL3LBo27NuaDPI6xHNfuUSilIHcrBkPfl4y0z6y2ByI455TjNRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -2867,6 +2877,11 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
+    },
+    "hono": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.2.tgz",
+      "integrity": "sha512-UG2jXGS/gkLH42l/1uROnwXpkjvvxkl3kpopL3LBo27NuaDPI6xHNfuUSilIHcrBkPfl4y0z6y2ByI455TjNRw=="
     },
     "is-arrayish": {
       "version": "0.3.2",

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -8,6 +8,7 @@
     "build": "wrangler deploy --outdir dist --dry-run"
   },
   "dependencies": {
+    "hono": "^4.9.2",
     "pmtiles": "^4.2.1"
   },
   "devDependencies": {

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -21,9 +21,6 @@ ALLOWED_ORIGINS = "*"
 # stored value.
 # FAVORED_ORIGINS = ""
 
-# Value of the Cache-Control header to return
-CACHE_CONTROL = "public, max-age=3600"
-
 # Rate limiter configuration
 [[unsafe.bindings]]
 name = "PER_USER_RATE_LIMITER"


### PR DESCRIPTION
This refactors the Cloudflare Worker code to use [Hono](https://hono.dev), an HTTP framework that fits nicely with Workers and other JS edge computing environments.

In the process, I also refactored the caching strategy to be more effective. Responses should now be cached automatically by Cloudflare's CDN, based on the `Cache-Control` header set in the response. This has a side-effect on the rate limits applied to clients, because requests that hit the cache will not count towards the rate limit. These requests also don't end up costing us anything though, since the Worker isn't invoked, so I don't think it's a problem.

Using a framework like Hono will make it easier to add features to the worker code in the future, including:
- serving other static assets (sprites, stylesheets, etc)
- serving a static website to provide documentation for the tileservice