### PR TITLE
Reorganize tileset URLs into /vector/ and /raster/ subdirectories

### DIFF
--- a/cloudflare/.gitignore
+++ b/cloudflare/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.wrangler

--- a/cloudflare/biome.json
+++ b/cloudflare/biome.json
@@ -1,6 +1,8 @@
 {
-  "files": {
-    "includes": ["**", "!dist"]
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
   },
   "linter": {
     "enabled": true

--- a/renderer/render_once.sh
+++ b/renderer/render_once.sh
@@ -62,7 +62,7 @@ fi
 echo 'Uploading planet to s3 bucket in background'
 aws s3 cp "$PLANET" s3://osmus-tile/ --only-show-errors &
 # also upload the same data to a Cloudflare R2 bucket (testing this as a new hosting option)
-rclone copyto "$PLANET" osmus-r2://osmus-tile/openmaptiles.pmtiles --s3-no-check-bucket &
+rclone copyto "$PLANET" osmus-r2://osmus-tile/vector/openmaptiles.pmtiles --s3-no-check-bucket &
 
 # Render optional layers
 for file in "$DIR/layers/"*.yml; do
@@ -91,7 +91,7 @@ for file in "$DIR/layers/"*.yml; do
 		# env AWS_PROFILE=osmus-r2 aws s3 cp "$WORKING_DIR/data/$layer_name.pmtiles" s3://osmus-tile/ --only-show-errors
 		# NOTE: the above doesn't work right now due to an S3/R2 compatibility issue; as a workaround
 		# we'll use rclone for now:
-		rclone copyto "$WORKING_DIR/data/$layer_name.pmtiles" "osmus-r2://osmus-tile/$layer_name.pmtiles" --s3-no-check-bucket
+		rclone copyto "$WORKING_DIR/data/$layer_name.pmtiles" "osmus-r2://osmus-tile/vector/$layer_name.pmtiles" --s3-no-check-bucket
 
 		rm -rf "$WORKING_DIR/data/$layer_name.pmtiles"
 	} &


### PR DESCRIPTION
Partially addresses #37.

As mentioned in that issue, moving tilesets out of the root directory of the bucket helps keep assets organized and avoid name collisions. We considered using `/tiles/` or `/tilesets/` as the prefix, but settled on `/vector/` and `/raster/` because it tells you something useful about the type of data found there, and it's more aesthetically pleasant in the URLs since the domain `tiles.openstreetmap.us` already includes "tiles", so having it repeated in the path felt redundant and clunky.

As a comparison, here's what the old URL paths looked like:
- `https://tiles.openstreetmap.us/openmaptiles.json`
- `https://tiles.openstreetmap.us/trails.json`
- `https://tiles.openstreetmap.us/hillshade.json`

These are TileJSON URLs; the tiles are available at similar URLs, but drop the `.json` and add `/{z}/{x}/{y}.{ext}`.

And here's what the new ones will be:
- `https://tiles.openstreetmap.us/vector/openmaptiles.json`
- `https://tiles.openstreetmap.us/vector/trails.json`
- `https://tiles.openstreetmap.us/raster/hillshade.json`

Like before, the tiles themselves are served under the same URL prefix as the TileJSONs.

**This change will not break existing maps**, because the Cloudflare worker will still serve data from PMTiles archives in the root of the bucket. NEW data will be uploaded to the new paths, so data consumers should update if they want fresh data. In a future PR, after all known data consumers are updated, I'll remove the unprefixed URL support from the CF worker, and delete the old (stale) .pmtiles assets from the bucket root.