### PR TITLE
Pin planetiler to v0.9.2 to temporarily avoid boundary bug

### DIFF
--- a/renderer/render_once.sh
+++ b/renderer/render_once.sh
@@ -22,8 +22,8 @@ pyosmium-up-to-date -vvvv --size 10000 "$WORKING_DIR/data/sources/planet.osm.pbf
 # Remove excess docker files from past runs
 docker system prune --force
 
-# Make sure we have the latest planetiler
-docker pull ghcr.io/onthegomap/planetiler:latest
+# Pull planetiler docker container.  Temporarily pin to v0.9.2 to avoid bug
+docker pull ghcr.io/onthegomap/planetiler:0.9.2
 
 docker run -e JAVA_TOOL_OPTIONS='-Xmx2g' \
 	-v "$WORKING_DIR/data":/data \


### PR DESCRIPTION
A recent change in Planetiler (onthegomap/planetiler/pull/1341) has led to some less than ideal boundary rendering in OSM Americana (osm-americana/openstreetmap-americana/issues/1280).  It seems the render script here is pulling the very latest Planetiler docker container every time.  This PR pins the pull to target v0.9.2 specifically as that is the latest release prior the change.  

It's also possible pulling [ghcr.io/onthegomap/planetiler:release](https://ghcr.io/onthegomap/planetiler:release) might be the right move if we don't want to live on the bleeding edge.  `release` appears to point to the latest release while `latest` appears to point to a snapshot built from the latest commit to main.



