### PR TITLE
Add hash parameter to tileset viewer

### DIFF
--- a/website/viewer/index.js
+++ b/website/viewer/index.js
@@ -587,7 +587,8 @@ export async function initTilesetViewer(config) {
     zoom: initialZoom,
     dragRotate: false,
     pitchWithRotate: false,
-    touchZoomRotate: false
+    touchZoomRotate: false,
+    hash: "map"
   });
 
   map.addControl(new ZoomControl(), "bottom-left");


### PR DESCRIPTION
Added a `#map=z/x/y` parameter to the URL for the tileset viewer based on the map’s current viewport. This makes it easier to share a link to a specific area of the map. I went with `map` as a named parameter instead of the unlabeled `z/x/y` format so that we can add more parameters in the future, for example to toggle layers or select a specific feature, without breaking existing links.