### PR TITLE
Remove unused attributes and layers from trails tileset

### DIFF
--- a/renderer/layers/trails.yml
+++ b/renderer/layers/trails.yml
@@ -11,7 +11,7 @@ layers:
     features:
       - source: osm
         geometry: line
-        min_zoom: 5
+        min_zoom: 10
         min_size: 1
         include_when: &trails_filter
           # gather any roads, paths, or ferries that are explicitly marked as trails or portages
@@ -109,26 +109,8 @@ layers:
               # exclude paths that go along roads
               - is_sidepath: yes
         attributes: &trail_attributes
-          - key: OSM_ID
-            value: ${feature.id}
-          - key: OSM_TYPE
-            value: ${feature.osm_type}
-          - key: OSM_VERSION
-            value: ${feature.osm_version}
           - key: OSM_TIMESTAMP
             value: ${feature.osm_timestamp}
-          - key: OSM_CHANGESET
-            value: ${feature.osm_changeset}
-          - key: OSM_USER_NAME
-            value: ${feature.osm_user_name}
-          - key: MIN_LAT
-            value: ${feature.min_lat}
-          - key: MIN_LON
-            value: ${feature.min_lon}
-          - key: MAX_LAT
-            value: ${feature.max_lat}
-          - key: MAX_LON
-            value: ${feature.max_lon}
           - key: access
             tag_value: access
           - key: atv
@@ -335,27 +317,12 @@ layers:
             tag_value: wheelchair
           - key: width
             tag_value: width
-  - id: trail_centerpoint
-    features:
-      # gather trail issues as points so we can render markers for them at any zoom level
-      - source: osm
-        geometry: line_midpoint
-        min_zoom: 7
-        include_when:
-          - __all__:
-            - __any__: *trails_filter
-            - __any__:
-              - fixme: __any__
-              - FIXME: __any__
-              - todo: __any__
-              - TODO: __any__
-        attributes: *trail_attributes
   - id: trail_poi
     features:
       # gather POIs mapped as nodes
       - source: osm
         geometry: point
-        min_zoom: 7
+        min_zoom: 10
         include_when:
           amenity: ranger_station
           highway: trailhead
@@ -367,20 +334,8 @@ layers:
             - viewpoint
           shelter_type: lean_to
         attributes: &poi_attributes
-          - key: OSM_ID
-            value: ${feature.id}
-          - key: OSM_TYPE
-            value: ${feature.osm_type}
-          - key: OSM_VERSION
-            value: ${feature.osm_version}
           - key: OSM_TIMESTAMP
             value: ${feature.osm_timestamp}
-          - key: OSM_CHANGESET
-            value: ${feature.osm_changeset}
-          - key: OSM_USER_NAME
-            value: ${feature.osm_user_name}
-          - key: AREA_Z0_PX2
-            value: ${feature.area('z0 px2')}
           - key: access
             tag_value: access
           - key: amenity
@@ -514,7 +469,7 @@ layers:
       # gather POIs mapped as areas for certain types
       - source: osm
         geometry: polygon_centroid_if_convex
-        min_zoom: 7
+        min_zoom: 10
         include_when:
           amenity: ranger_station
           tourism:
@@ -537,7 +492,7 @@ layers:
         attributes: *poi_attributes
       - source: osm
         geometry: point
-        min_zoom: 7
+        min_zoom: 10
         include_when:
           - leisure: slipway
           - waterway: access_point
@@ -557,7 +512,7 @@ layers:
         attributes: *poi_attributes
       - source: osm
         geometry: point
-        min_zoom: 7
+        min_zoom: 10
         include_when: &waterway_barriers_filter
           natural: beaver_dam
           waterway:
@@ -567,17 +522,17 @@ layers:
         attributes: *poi_attributes
       - source: osm
         geometry: line_midpoint
-        min_zoom: 7
+        min_zoom: 10
         include_when: *waterway_barriers_filter
         attributes: *poi_attributes
       - source: osm
         geometry: polygon_centroid_if_convex
-        min_zoom: 7
+        min_zoom: 10
         include_when: *waterway_barriers_filter
         attributes: *poi_attributes
       - source: osm
         geometry: line_midpoint
-        min_zoom: 7
+        min_zoom: 10
         include_when:
           - __all__:
             - lock: yes
@@ -588,116 +543,12 @@ layers:
         attributes: *poi_attributes
       - source: osm
         geometry: line_midpoint
-        min_zoom: 7
+        min_zoom: 10
         include_when:
           - __all__:
             - route: ferry
             - __any__: *trails_filter
         attributes: *poi_attributes
-      # gather protected areas as points
-      - source: osm
-        geometry: polygon_centroid_if_convex
-        min_zoom: 4
-        min_size: 5
-        include_when: &parks_filter
-          - __all__:
-            - name: __any__
-            - __any__:
-              - leisure:
-                - park
-                - nature_reserve
-              - boundary:
-                - national_park
-                - protected_area
-            - __not__:
-              - protected_area: historic_district
-        attributes: *poi_attributes
-      # gather trees at low zooms
-      - source: osm
-        geometry: point
-        min_zoom: 14
-        include_when:
-          natural: tree
-        attributes: *poi_attributes
-  # gather protected areas as polygons on separate layer
-  - id: park
-    features:
-      - source: osm
-        geometry: polygon
-        min_zoom: 4
-        min_size: 1
-        include_when: *parks_filter
-        attributes:
-          - key: OSM_ID
-            value: ${feature.id}
-          - key: OSM_TYPE
-            value: ${feature.osm_type}
-          - key: MIN_LAT
-            value: ${feature.min_lat}
-          - key: MIN_LON
-            value: ${feature.min_lon}
-          - key: MAX_LAT
-            value: ${feature.max_lat}
-          - key: MAX_LON
-            value: ${feature.max_lon}
-          - key: access
-            tag_value: access
-          - key: boundary
-            tag_value: boundary
-          - key: name
-            tag_value: name
-          - key: protected_area
-            tag_value: protected_area
-  # gather barriers as areas for rendering
-  - id: barrier_area
-    features:
-      - source: osm
-        geometry: polygon
-        min_zoom: 7
-        min_size: 1
-        include_when: &barrier_filter
-          - barrier: floating_boom
-          - man_made: breakwater
-          - natural: beaver_dam
-          - waterway:
-            - dam
-            - weir
-        attributes: &barrier_attributes
-          - key: OSM_ID
-            value: ${feature.id}
-          - key: OSM_TYPE
-            value: ${feature.osm_type}
-          - key: OSM_VERSION
-            value: ${feature.osm_version}
-          - key: OSM_TIMESTAMP
-            value: ${feature.osm_timestamp}
-          - key: OSM_CHANGESET
-            value: ${feature.osm_changeset}
-          - key: OSM_USER_NAME
-            value: ${feature.osm_user_name}
-          - key: barrier
-            tag_value: barrier
-          - key: canoe
-            tag_value: canoe
-          - key: intermittent
-            tag_value: intermittent
-          - key: man_made
-            tag_value: man_made
-          - key: portage
-            tag_value: portage
-          - key: natural
-            tag_value: natural
-          - key: waterway
-            tag_value: waterway
-  # gather barriers as lines for rendering
-  - id: barrier_line
-    features:
-      - source: osm
-        geometry: line
-        min_zoom: 7
-        min_size: 1
-        include_when: *barrier_filter
-        attributes: *barrier_attributes
 args:
   area:
     description: Geofabrik area to download


### PR DESCRIPTION
This PR trims a bunch of unused data from the `trails` tileset:

- removes the `park`, `barrier_area`, and `barrier_line` layers
- removes `MIN_LON`, `MIN_LAT`, `MAX_LON`, and `MAX_LAT` attributes from all layers
- removes `OSM_ID` and `OSM_TYPE` attributes from all layers (feature IDs already encode this)
- removes `OSM_VERSION`, `OSM_CHANGESET`, and `OSM_USER_NAME` attributes from all layers. keeps `OSM_TIMESTAMP` because OpenTrailMap still depends on it for now.
- increases the `trails` layer minzoom from z5 to z10
- increases the `trail_pois` layer minzoom from z7 to z10

Together these changes reduce the mean tile size by about 80%. It also builds faster by about a third.

Tested on `us-west.osm.pbf`.

Before:
```
Max tile sizes
                    z4    z5    z6    z7    z8    z9   z10   z11   z12   z13   z14   all
             park 104k  182k  125k   83k   69k   75k   68k   36k   17k   13k   10k  182k
        trail_poi 6.4k   12k   14k  532k  228k  135k   79k   71k   71k   41k  850k  850k
            trail    0  770k  585k  707k  636k  759k  614k  479k  293k  168k  277k  770k
     barrier_area    0     0     0   230   623   768   830    1k  2.2k  2.2k  2.3k  2.3k
     barrier_line    0     0     0  2.9k  4.3k  4.2k  3.8k  4.5k  3.5k  2.4k  2.8k  4.5k
trail_centerpoint    0     0     0   43k   28k   12k   10k  8.3k  6.3k    5k    5k   43k
        full tile 110k  966k  700k  1.3M  842k  974k  717k  537k  316k  176k  864k  1.3M
          gzipped  67k  578k  422k  688k  480k  550k  407k  299k  172k  100k  238k  688k

Max tile: 1.3M (gzipped: 688k)
Avg tile: 124k (gzipped: 72k) using weighted average based on OSM traffic
Number of tiles: 645,339
```

After:
```
Max tile sizes
           z10   z11   z12   z13   z14   all
    trail 224k  166k   98k   59k  103k  224k
trail_poi  35k   32k   31k   18k   10k   35k
full tile 247k  183k  105k   59k  106k  247k
  gzipped 138k  104k   60k   35k   59k  138k

Max tile: 247k (gzipped: 138k)
Avg tile: 22k (gzipped: 13k) using weighted average based on OSM traffic
Number of tiles: 282,359
```

**This is a breaking change**. However, I believe the only software that currently uses this tileset is OpenTrailMap (https://opentrailmap.us/) which has already been patched and no longer depends on any of the info that's being removed in this PR. https://paddlemap.net/ was using these tiles in the past, but appears to have switched to their own tiles.

This is also a stepping stone. **In the future, I plan to deprecate this tileset** and replace it with one built using [Layercake](https://github.com/osmus/layercake). Essentially the "trails" tileset would become a SQL query over Layercake's `highways` layer to select paths, footways, cycleways, etc, and then feed that data into Planetiler or Tippecanoe to produce a vector tileset. This transformation is pretty simple and mechanical, so it could easily be extended to other Layercake layers to produce additional data themes as needed.